### PR TITLE
force deletion of pre-existing winpe dir

### DIFF
--- a/build_winpe.ps1
+++ b/build_winpe.ps1
@@ -100,7 +100,7 @@ else
 }
 
 #Cleanup before starting any processing
-rmdir $pe_dir -Recurse
+rmdir $pe_dir -Recurse -Force
 
 if (!(Test-Path -path $pe_dir)) {New-Item $pe_dir -Type Directory}
 if (!(Test-Path -path $pe_src)) {New-Item $pe_src -Type Directory}


### PR DESCRIPTION
this helps against permission problems when re-running
http://openqa.opensuse.org/openqa/temp/windowsbcdbug.PNG
