### PR TITLE
Set ramdisktftpblocksize to 8192

### DIFF
--- a/bcdcreate.cmd
+++ b/bcdcreate.cmd
@@ -17,6 +17,7 @@ set BASEDIR=%1
   %BCDEDIT% -create {ramdiskoptions} -d "Ramdisk options"
   %BCDEDIT% -set {ramdiskoptions} ramdisksdidevice boot
   %BCDEDIT% -set {ramdiskoptions} ramdisksdipath \Boot\boot.sdi
+  %BCDEDIT% -set {ramdiskoptions} ramdisktftpblocksize 8192
   for /f "tokens=3" %%a in ('%BCDEDIT% -create -d "Windows PE" -application osloader') do set GUID=%%a
   %BCDEDIT% -set %GUID% systemroot \Windows
   %BCDEDIT% -set %GUID% detecthal Yes


### PR DESCRIPTION
the default ramdisktftpblocksize is 1456 for bootmgr.exe created on a windows 2012 R2 server. The  winpe.wim file can get pretty large. In My case it was 273 MB in size.

So, in order to have a successful file transfer (at least with the Twisted implementation of tftp) the client must request a block size larger then the default.

1456 \* 2^16 is 91 MB

A value of 8192 for ramdisktftpblocksize will allow file transfers of 512 MB in size.
