### PR TITLE
avoid hardcoded admin-server IP

### DIFF
--- a/build_winpe.ps1
+++ b/build_winpe.ps1
@@ -186,11 +186,11 @@ popd
 Add-Content $startnet_cmd "`n"
 if($built_for_crowbar)
 {
-  Add-Content $startnet_cmd "`n net use $crowbar_mountpoint \\$crowbar_server_ip\$crowbar_share"
+  Add-Content $startnet_cmd "`n powershell `"`$DHCPServer = (Get-WMIObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=True -ComputerName . | Select-Object -Property DHCPServer).DHCPServer ; net use $crowbar_mountpoint \\`$DHCPServer\$crowbar_share`""
   Add-Content $startnet_cmd "`n $crowbar_mountpoint\$crowbar_folder\$crowbar_source\setup.exe /noreboot /unattend:$crowbar_mountpoint\$crowbar_folder\$crowbar_unattend\unattended.xml"
   Add-Content $startnet_cmd "`n copy $crowbar_mountpoint\$crowbar_folder\$crowbar_extra\set_state.ps1 \"
   Add-Content $startnet_cmd "`n powershell -ExecutionPolicy RemoteSigned \set_state.ps1"
-  Add-Content $startnet_cmd "`exit"
+  Add-Content $startnet_cmd "`n exit"
 }
 else
 {


### PR DESCRIPTION
by querying the current DHCP server at install-time
and using this IP to connect to its samba share

This allows to share prepared windows-install-dirs between clouds.
