### PR TITLE
fix crowbar admin server detection

### DIFF
--- a/build_winpe.ps1
+++ b/build_winpe.ps1
@@ -186,7 +186,7 @@ popd
 Add-Content $startnet_cmd "`n"
 if($built_for_crowbar)
 {
-  Add-Content $startnet_cmd "`n powershell `"`$DHCPServer = @(Get-WMIObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=True -ComputerName . | Select-Object -Property DHCPServer).DHCPServer[0] ; net use $crowbar_mountpoint \\`$DHCPServer\$crowbar_share`""
+  Add-Content $startnet_cmd "`n powershell `"`$DHCPServer = @(Get-WMIObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=True -ComputerName . | Select-Object -Property DHCPServer).DHCPServer[0] ; Write-Host DHCPServer=`$DHCPServer ; net use $crowbar_mountpoint \\`$DHCPServer\$crowbar_share`""
   Add-Content $startnet_cmd "`n $crowbar_mountpoint\$crowbar_folder\$crowbar_source\setup.exe /noreboot /unattend:$crowbar_mountpoint\$crowbar_folder\$crowbar_unattend\unattended.xml"
   Add-Content $startnet_cmd "`n copy $crowbar_mountpoint\$crowbar_folder\$crowbar_extra\set_state.ps1 \"
   Add-Content $startnet_cmd "`n powershell -ExecutionPolicy RemoteSigned \set_state.ps1"

--- a/build_winpe.ps1
+++ b/build_winpe.ps1
@@ -186,7 +186,7 @@ popd
 Add-Content $startnet_cmd "`n"
 if($built_for_crowbar)
 {
-  Add-Content $startnet_cmd "`n powershell `"`$DHCPServer = (Get-WMIObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=True -ComputerName . | Select-Object -Property DHCPServer).DHCPServer ; net use $crowbar_mountpoint \\`$DHCPServer\$crowbar_share`""
+  Add-Content $startnet_cmd "`n powershell `"`$DHCPServer = @(Get-WMIObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=True -ComputerName . | Select-Object -Property DHCPServer).DHCPServer[0] ; net use $crowbar_mountpoint \\`$DHCPServer\$crowbar_share`""
   Add-Content $startnet_cmd "`n $crowbar_mountpoint\$crowbar_folder\$crowbar_source\setup.exe /noreboot /unattend:$crowbar_mountpoint\$crowbar_folder\$crowbar_unattend\unattended.xml"
   Add-Content $startnet_cmd "`n copy $crowbar_mountpoint\$crowbar_folder\$crowbar_extra\set_state.ps1 \"
   Add-Content $startnet_cmd "`n powershell -ExecutionPolicy RemoteSigned \set_state.ps1"


### PR DESCRIPTION
this failed in SUSE QA cloud because two identical entries were returned
