### PR TITLE
Revert changes for admin server IP detection

### DIFF
--- a/build_winpe.ps1
+++ b/build_winpe.ps1
@@ -186,7 +186,7 @@ popd
 Add-Content $startnet_cmd "`n"
 if($built_for_crowbar)
 {
-  Add-Content $startnet_cmd "`n powershell `"`$DHCPServer = @(Get-WMIObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=True -ComputerName . | Select-Object -Property DHCPServer).DHCPServer[0] ; Write-Host DHCPServer=`$DHCPServer ; net use $crowbar_mountpoint \\`$DHCPServer\$crowbar_share`""
+  Add-Content $startnet_cmd "`n powershell `"`$DHCPServer = @(Get-WMIObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=True -ComputerName . | Select-Object -Property DHCPServer).DHCPServer[0] ; net use $crowbar_mountpoint \\`$DHCPServer\$crowbar_share`""
   Add-Content $startnet_cmd "`n $crowbar_mountpoint\$crowbar_folder\$crowbar_source\setup.exe /noreboot /unattend:$crowbar_mountpoint\$crowbar_folder\$crowbar_unattend\unattended.xml"
   Add-Content $startnet_cmd "`n copy $crowbar_mountpoint\$crowbar_folder\$crowbar_extra\set_state.ps1 \"
   Add-Content $startnet_cmd "`n powershell -ExecutionPolicy RemoteSigned \set_state.ps1"

--- a/build_winpe.ps1
+++ b/build_winpe.ps1
@@ -186,11 +186,11 @@ popd
 Add-Content $startnet_cmd "`n"
 if($built_for_crowbar)
 {
-  Add-Content $startnet_cmd "`n powershell `"`$DHCPServer = (Get-WMIObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=True -ComputerName . | Select-Object -Property DHCPServer).DHCPServer ; net use $crowbar_mountpoint \\`$DHCPServer\$crowbar_share`""
+  Add-Content $startnet_cmd "`n net use $crowbar_mountpoint \\$crowbar_server_ip\$crowbar_share"
   Add-Content $startnet_cmd "`n $crowbar_mountpoint\$crowbar_folder\$crowbar_source\setup.exe /noreboot /unattend:$crowbar_mountpoint\$crowbar_folder\$crowbar_unattend\unattended.xml"
   Add-Content $startnet_cmd "`n copy $crowbar_mountpoint\$crowbar_folder\$crowbar_extra\set_state.ps1 \"
   Add-Content $startnet_cmd "`n powershell -ExecutionPolicy RemoteSigned \set_state.ps1"
-  Add-Content $startnet_cmd "`n exit"
+  Add-Content $startnet_cmd "`exit"
 }
 else
 {

--- a/build_winpe.ps1
+++ b/build_winpe.ps1
@@ -186,7 +186,7 @@ popd
 Add-Content $startnet_cmd "`n"
 if($built_for_crowbar)
 {
-  Add-Content $startnet_cmd "`n powershell `"`$DHCPServer = @(Get-WMIObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=True -ComputerName . | Select-Object -Property DHCPServer).DHCPServer[0] ; net use $crowbar_mountpoint \\`$DHCPServer\$crowbar_share`""
+  Add-Content $startnet_cmd "`n powershell `"`$DHCPServer = (Get-WMIObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=True -ComputerName . | Select-Object -Property DHCPServer).DHCPServer ; net use $crowbar_mountpoint \\`$DHCPServer\$crowbar_share`""
   Add-Content $startnet_cmd "`n $crowbar_mountpoint\$crowbar_folder\$crowbar_source\setup.exe /noreboot /unattend:$crowbar_mountpoint\$crowbar_folder\$crowbar_unattend\unattended.xml"
   Add-Content $startnet_cmd "`n copy $crowbar_mountpoint\$crowbar_folder\$crowbar_extra\set_state.ps1 \"
   Add-Content $startnet_cmd "`n powershell -ExecutionPolicy RemoteSigned \set_state.ps1"


### PR DESCRIPTION
The changes to derive the admin server IP from the DHCP server information in the Win32_NetworkAdapterConfiguration object don't seem to work reliably when the windows nodes have more than one Network Card and the admin network is not connected to the first of those cards. This simply reverts those commits and goes back to setting in statically during build time.

Should fix: https://bugzilla.novell.com/show_bug.cgi?id=866797
